### PR TITLE
Migrate to WFA2-lib v2.3.4

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -2118,25 +2118,26 @@ package:
   size: 98368
   timestamp: 1689789963646
 - name: wfa2-lib
-  version: 2.3.3
+  version: 2.3.4
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/bioconda/linux-64/wfa2-lib-2.3.3-h4ac6f70_2.tar.bz2
+  url: https://conda.anaconda.org/bioconda/linux-64/wfa2-lib-2.3.4-h4ac6f70_0.tar.bz2
   hash:
-    md5: 04548777a2edb93fcc07c2df721371ee
-    sha256: 9c0226e6c753aab3f681ae8a6c86341a023f40f7d069d407b5ee6fe9717e7f42
+    md5: 75e9b7b0f4f949c3dc0bb530c45fa863
+    sha256: f6befd084b19f8f3e680e1cb4c0984eb4e7aab5d0a8f7ae684f7070dc6d15d94
   optional: false
   category: main
-  build: h4ac6f70_2
+  build: h4ac6f70_0
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 0
   license: MIT
-  size: 120236
-  timestamp: 1695229142864
+  license_family: MIT
+  size: 125511
+  timestamp: 1695746679105
 - name: wheel
   version: 0.41.2
   manager: conda

--- a/pixi.toml
+++ b/pixi.toml
@@ -16,7 +16,7 @@ twine-check = { cmd = [ "twine", "check", "dist/*" ], depends_on = [ "build-sdis
 clean = { cmd = [ "rm", "-rf", "build/", "dist/" ] }
 
 [dependencies]
-wfa2-lib = "==2.3.3=h4ac6f70_2"
+wfa2-lib = "~=2.3.4"
 python = ">=3.8,<4"
 pip = ""
 python-build = "=1"


### PR DESCRIPTION
This PR will track work to migrate to the v2.3.4 API of WFA2-lib.